### PR TITLE
Rna

### DIFF
--- a/atlas/rules/assemble.snakefile
+++ b/atlas/rules/assemble.snakefile
@@ -273,6 +273,19 @@ else:
 
         return params
 
+    def spades_output(wc):
+        if config['spades_preset']=='rna':
+            output_name='transcripts'
+        elif (config['spades_preset']=='meta') or (config['spades_preset']=='normal'):
+            if config['spades_use_scaffolds']:
+                output_name= "scaffolds"
+            else:
+                output_name= "contigs"
+        else:
+            raise Exception("Don't know 'spades_preset' in config file.")
+
+        return f"{wc.sample}/assembly/{output_name}.fasta"
+
 
     rule run_spades:
         input:
@@ -280,8 +293,7 @@ else:
                 fraction=ASSEMBLY_FRACTIONS,
                 assembly_preprocessing_steps=assembly_preprocessing_steps)
         output:
-            "{sample}/assembly/contigs.fasta",
-            "{sample}/assembly/scaffolds.fasta"
+            spades_output
         benchmark:
             "logs/benchmarks/assembly/spades/{sample}.txt"
         params:
@@ -312,7 +324,7 @@ else:
     localrules: rename_spades_output
     rule rename_spades_output:
         input:
-            "{{sample}}/assembly/{sequences}.fasta".format(sequences= 'scaffolds' if config['spades_use_scaffolds'] else 'contigs' )
+            rules.run_spades.output[0]
         output:
             temp("{sample}/assembly/{sample}_raw_contigs.fasta")
         shell:


### PR DESCRIPTION

To use this branch:

* Install dependencies with conda as described in the Readme. 

```
git clone https://github.com/metagenome-atlas/atlas.git
cd atlas
git checkout rna
git pull
pip install --editable .
```

It is important to modify the config file:
```
data_type: metatranscriptome # metagenome or metatranscriptome
assembler: spades
spades_preset: rna 
contaminant_references:
  PhiX: /path/to/databases/phiX174_virus.fa
  rRNA: /path/to/databases/Silva.fasta

genecatalog:
  source: contigs
...
```
The contamination database for "rRNA" gets automaticly added when run `atlas init --data-type metatranscriptome`

Run atlas as follows:

```
atlas run genecatalog <options>
```

This assembles the metatranscriptome with rnaSpades, predict genes with prodigal, clusters them with linclust and annotates them with eggNOG. 

any other feature requests?



If you have run spades before maybe it's a good Idea to remove previous files:
In the atlas working dir run:
```
rm */assembly
```


