### PR TITLE
Fix bin naming collision error

### DIFF
--- a/atlas/rules/binning.snakefile
+++ b/atlas/rules/binning.snakefile
@@ -266,7 +266,7 @@ rule get_unique_cluster_attribution:
                           "You can either remove the binner (for all samples) from the config.yaml file or the sample from the sample.tsv"
                             )
             raise Exception("No bins detected with binner {wildcards.binner} in sample {wildcards.sample}.")
-        new_d.to_csv(output[0],sep='\t')
+        new_d.to_csv(output[0],sep='\t',header=False)
 #
 
 rule get_maxbin_cluster_attribution:


### PR DESCRIPTION
Fixes #296 

We might also want to consider setting pandas to v0.23 for ATLAS in case other aspects of the ATLAS code have also been affected by the change in pandas defaults. Once changes to pandas have been fully assessed for their impact on the ATLAS code, then pandas could be moved to 1.0.x, for example.

However, one would need to ensure that requiring pandas = 0.23 does not break any of the other conda installs.

