### PR TITLE
Tiny typo corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ For more details see [documentation](https://metagenome-atlas.rtfd.io/).
 
 # Assembly based metagenomics
 
-Atlas is a easy to use metagenomic pipeline
+Atlas is an easy to use metagenomic pipeline
 
 ![scheme of workflow](resources/images/ATLAS_scheme.png?raw=true)
 
 # Setup
-Atlas should be run on a _linux_ sytem, with enough memory (min ~50GB but assembly usually requires 250GB).
+Atlas should be run on a _Linux_ sytem, with enough memory (min ~50GB but assembly usually requires 250GB).
 The only dependency is the _conda package manager_, which can easy be installed with [anaconda](http://anaconda.org/).
 We recommend you to create a conda environment for atlas to avoid any conflicts of versions.
 


### PR DESCRIPTION
"a easy" -> "an easy"
lowercase "linux" -> capitalized "Linux"