### PR TITLE
Decycle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,10 +139,11 @@ jobs:
               .test/test_assembly.sh --resources mem=$MEM java_mem=$MEM --config  threads=$N_THREADS mem=$MEM --jobs=$N_THREADS --restart-times=2 --omit-from build_qc_report build_assembly_report
       - run:
           command: |
-            mkdir -p /tmp/logs
+            mkdir -p /tmp/logs/snakemake
             cp -r .test/Test_assembly/Streptococcus/logs /tmp/logs/Streptococcus
             cp -r .test/Test_assembly/Mycoplasma/logs /tmp/logs/Mycoplasma
             cp -r .test/Test_assembly/logs /tmp/logs/global
+            cp -r .test/Test_assembly/.snakemake/log/* /tmp/logs/snakemake
           when: on_fail
       - store_artifacts:
           path: /tmp/logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,12 +136,23 @@ jobs:
           name: test assembly
           command: |
               source activate ./atlasenv
-              .test/test_assembly.sh --resources mem=$MEM java_mem=$MEM --jobs=$N_THREADS --restart-times=2 --omit-from build_qc_report build_assembly_report
-      # - store_test_results:
-      #     path: .test/Test_assembly/reports
-      # - store_artifacts:
-      #     path: .test/Test_assembly/reports
-      #     destination: assembly_results
+              .test/test_assembly.sh --resources mem=$MEM java_mem=$MEM --config  threads=$N_THREADS mem=$MEM --jobs=$N_THREADS --restart-times=2 --omit-from build_qc_report build_assembly_report
+      - run:
+          command: |
+            mkdir -p /tmp/logs
+            cp -r .test/Test_assembly/Streptococcus/logs /tmp/logs/Streptococcus
+            cp -r .test/Test_assembly/Mycoplasma/logs /tmp/logs/Mycoplasma
+            cp -r .test/Test_assembly/logs /tmp/logs/global
+          when: on_fail
+      - store_artifacts:
+          path: /tmp/logs
+          destination: assembly_logs
+      - store_test_results:
+          path: .test/Test_assembly/reports
+      - store_artifacts:
+          path: .test/Test_assembly/reports
+          destination: assembly_results
+
 
       - run:
           name: run genecatalog

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,23 +136,12 @@ jobs:
           name: test assembly
           command: |
               source activate ./atlasenv
-              .test/test_assembly.sh --resources mem=$MEM java_mem=$MEM --config  threads=$N_THREADS mem=$MEM --jobs=$N_THREADS --restart-times=2 --omit-from build_qc_report build_assembly_report
-      - run:
-          command: |
-            mkdir -p /tmp/logs/snakemake
-            cp -r .test/Test_assembly/Streptococcus/logs /tmp/logs/Streptococcus
-            cp -r .test/Test_assembly/Mycoplasma/logs /tmp/logs/Mycoplasma
-            cp -r .test/Test_assembly/logs /tmp/logs/global
-            cp -r .test/Test_assembly/.snakemake/log/* /tmp/logs/snakemake
-          when: on_fail
-      - store_artifacts:
-          path: /tmp/logs
-          destination: assembly_logs
-      - store_test_results:
-          path: .test/Test_assembly/reports
-      - store_artifacts:
-          path: .test/Test_assembly/reports
-          destination: assembly_results
+              .test/test_assembly.sh --resources mem=$MEM java_mem=$MEM --jobs=$N_THREADS --restart-times=2 --omit-from build_qc_report build_assembly_report
+      # - store_test_results:
+      #     path: .test/Test_assembly/reports
+      # - store_artifacts:
+      #     path: .test/Test_assembly/reports
+      #     destination: assembly_results
 
 
       - run:
@@ -165,7 +154,7 @@ jobs:
     <<: *defaults
     environment:
       N_THREADS: 2
-      MEM: 4
+      MEM: 3
     resource_class: medium
     steps:
       - attach_workspace:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Version](https://anaconda.org/bioconda/metagenome-atlas/badges/version.svg)](https://anaconda.org/bioconda/metagenome-atlas)
 [![Bioconda](https://img.shields.io/conda/dn/bioconda/metagenome-atlas.svg?label=Bioconda )](https://anaconda.org/bioconda/metagenome-atlas)
 [![Documentation Status](https://readthedocs.org/projects/metagenome-atlas/badge/?version=latest)](https://metagenome-atlas.readthedocs.io/en/latest/?badge=latest)
+[![Gitter](https://badges.gitter.im/metagenome-atlas/community.svg)](https://gitter.im/metagenome-atlas/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![follow on twitter](https://img.shields.io/twitter/follow/SilasKieser.svg?style=social&label=Follow)](https://twitter.com/search?f=tweets&q=%40SilasKieser%20%23metagenomeAtlas&src=typd)
 
 

--- a/atlas/__init__.py
+++ b/atlas/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.5.0"
+__version__ = "2.6a1"
 
 from .scripts import utils
 

--- a/atlas/__init__.py
+++ b/atlas/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.4.5"
+__version__ = "2.5.0"
 
 from .scripts import utils
 

--- a/atlas/__init__.py
+++ b/atlas/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.4.4"
+__version__ = "2.4.5"
 
 from .scripts import utils
 

--- a/atlas/atlas.py
+++ b/atlas/atlas.py
@@ -129,7 +129,7 @@ def run_workflow(workflow, working_dir,config_file, jobs, profile, dryrun, snake
         "snakemake --snakefile {snakefile} --directory {working_dir} "
         "{jobs} --rerun-incomplete "
         "--configfile '{config_file}' --nolock "
-        " {profile} --use-conda {conda_prefix} {dryrun} "
+        " {profile} --use-conda {conda_prefix} {dryrun} --conda-frontend mamba "
         " {target_rule} "
         " {args} "
     ).format(

--- a/atlas/atlas.py
+++ b/atlas/atlas.py
@@ -130,6 +130,7 @@ def run_workflow(workflow, working_dir,config_file, jobs, profile, dryrun, snake
         "{jobs} --rerun-incomplete "
         "--configfile '{config_file}' --nolock "
         " {profile} --use-conda {conda_prefix} {dryrun} --conda-frontend mamba "
+        " --scheduler greedy "
         " {target_rule} "
         " {args} "
     ).format(

--- a/atlas/atlas.py
+++ b/atlas/atlas.py
@@ -129,7 +129,7 @@ def run_workflow(workflow, working_dir,config_file, jobs, profile, dryrun, snake
         "snakemake --snakefile {snakefile} --directory {working_dir} "
         "{jobs} --rerun-incomplete "
         "--configfile '{config_file}' --nolock "
-        " {profile} --use-conda {conda_prefix} {dryrun} --conda-frontend mamba "
+        " {profile} --use-conda {conda_prefix} {dryrun} "
         " --scheduler greedy "
         " {target_rule} "
         " {args} "
@@ -184,6 +184,7 @@ def run_download(db_dir,jobs, snakemake_args):
     cmd = (
         "snakemake --snakefile {snakefile} "
         "--jobs {jobs} --rerun-incomplete "
+        "--conda-frontend mamba --scheduler greedy "
         "--nolock  --use-conda  --conda-prefix {conda_prefix} "
         "--config database_dir='{db_dir}' {add_args} "
         "{args}"

--- a/atlas/default_values.py
+++ b/atlas/default_values.py
@@ -275,7 +275,7 @@ def make_default_config():
                     "default":5,
                     "assembly":24,
                     "long":12,
-                    "simple_job":0.5
+                    "simple_job":1
                     }
 
     # conf["diamond_run_mode"] = "fast"

--- a/atlas/default_values.py
+++ b/atlas/default_values.py
@@ -183,7 +183,7 @@ def make_default_config():
     conf["minimum_contig_length"] = MINIMUM_CONTIG_LENGTH
     conf["prefilter_minimum_contig_length"] = PREFILTER_MINIMUM_CONTIG_LENGTH
     conf["spades_k"] = SPADES_K
-    conf["spades_use_scaffolds"] = False
+    conf["spades_use_scaffolds"] = True
     conf["spades_preset"] = "meta"
     conf["spades_extra"] = ""
     conf["spades_skip_BayesHammer"] = False

--- a/atlas/envs/checkm.yaml
+++ b/atlas/envs/checkm.yaml
@@ -4,3 +4,4 @@ channels:
     - defaults
 dependencies:
     - checkm-genome =1.1.*
+    - python =3.6 

--- a/atlas/envs/eggNOG.yaml
+++ b/atlas/envs/eggNOG.yaml
@@ -3,5 +3,6 @@ channels:
     - bioconda
     - defaults
 dependencies:
-    - eggnog-mapper>=2.0.1
+    - eggnog-mapper = 2.1
+    - diamond = 2.0.6
     - wget # to download_eggnog_data on macOS

--- a/atlas/envs/gtdbtk.yaml
+++ b/atlas/envs/gtdbtk.yaml
@@ -3,4 +3,4 @@ channels:
 - bioconda
 - defaults
 dependencies:
-- gtdbtk =1.3.*
+- gtdbtk =1.5.*

--- a/atlas/envs/report.yaml
+++ b/atlas/envs/report.yaml
@@ -3,14 +3,10 @@ channels:
     - bioconda
     - defaults
 dependencies:
-    - numpy=1.13.1
-    - python=3.6
-    - pandas=0.20.3
-    - plotly=2.2.2
-    - ipython
-    - seaborn=0.8
-    - snakemake=5.7.4 #or5.8.2 sheetname error
+    - python=3.7
     - docutils
-    - pip
-    - pip:
-      - cufflinks==0.12.1
+    - pandas=1.2
+    - plotly=4.14
+    - ipython
+    - seaborn=0.11
+    - snakemake=6.0

--- a/atlas/report/assembly_report.py
+++ b/atlas/report/assembly_report.py
@@ -1,6 +1,5 @@
 import os,sys
 f = open(os.devnull, 'w'); sys.stdout = f # block cufflinks to plot strange code
-from cufflinks import iplot
 log=open(snakemake.log[0],"w")
 sys.stderr= log
 sys.stdout= log

--- a/atlas/report/assembly_report.py
+++ b/atlas/report/assembly_report.py
@@ -1,8 +1,22 @@
 import os,sys
-f = open(os.devnull, 'w'); sys.stdout = f # block cufflinks to plot strange code
-log=open(snakemake.log[0],"w")
-sys.stderr= log
-sys.stdout= log
+import logging, traceback
+logging.basicConfig(filename=snakemake.log[0],
+                    level=logging.INFO,
+                    format='%(asctime)s %(message)s',
+                    datefmt='%Y-%m-%d %H:%M:%S',
+                    )
+def handle_exception(exc_type, exc_value, exc_traceback):
+    if issubclass(exc_type, KeyboardInterrupt):
+        sys.__excepthook__(exc_type, exc_value, exc_traceback)
+        return
+
+    logger.error(''.join(["Uncaught exception: ",
+                         *traceback.format_exception(exc_type, exc_value, exc_traceback)
+                         ])
+                 )
+# Install exception handler
+sys.excepthook = handle_exception
+
 
 import pandas as pd
 import plotly.graph_objs as go
@@ -16,52 +30,13 @@ PLOTLY_PARAMS = dict(
 )
 
 atlas_dir= os.path.abspath(os.path.join(os.path.dirname(__file__),'..'))
-sys.path.append(os.path.join(atlas_dir,'scripts'))
-from utils.parsers_bbmap import parse_bbmap_log_file
 
 
 
-
-def parse_map_stats(sample_data, out_tsv):
-    stats_df = pd.DataFrame()
-    for sample in sample_data.keys():
-        df = pd.read_csv(sample_data[sample]["contig_stats"],sep='\t')
-        assert df.shape[0] == 1, "Assumed only one row in file {}; found {}".format(
-            sample_data[sample]["contig_stats"], df.iloc[0]
-        )
-        df = df.iloc[0]
-        df.name = sample
-        genes_df = pd.read_csv(sample_data[sample]["gene_table"], index_col=0,sep='\t')
-        df["N_Predicted_Genes"] = genes_df.shape[0]
-        used_reads,mapped_reads= parse_bbmap_log_file(sample_data[sample]["mapping_log"])
-        df["Assembled_Reads"] = mapped_reads
-        df["Percent_Assembled_Reads"] = mapped_reads/used_reads *100
-
-        stats_df = stats_df.append(df)
-    stats_df = stats_df.loc[:, ~ stats_df.columns.str.startswith("scaf_")]
-    stats_df.columns = stats_df.columns.str.replace("ctg_", "")
-    stats_df.to_csv(out_tsv, sep="\t")
-    return stats_df
+def main(combined_stats, report_out):
 
 
-def main(samples, contig_stats, gene_tables, mapping_logs, report_out, combined_stats):
-    sample_data = {}
-    for sample in samples:
-        sample_data[sample] = {}
-        for c_stat in contig_stats:
-            # underscore version was for simplified local testing
-            # if "%s_" % sample in c_stat:
-            if "%s/" % sample in c_stat:
-                sample_data[sample]["contig_stats"] = c_stat
-        for g_table in gene_tables:
-            # if "%s_" % sample in g_table:
-            if "%s/" % sample in g_table:
-                sample_data[sample]["gene_table"] = g_table
-        for mapping_log in mapping_logs:
-            # if "%s_" % sample in mapping_log:
-            if "%s/" % sample in mapping_log:
-                sample_data[sample]["mapping_log"] = mapping_log
-    df = parse_map_stats(sample_data, combined_stats)
+    df = pd.read_csv(combined_stats,sep='\t',index_col=0)
     div = {}
     labels = {
         "Percent_Assembled_Reads": "Percent of Assembled Reads",
@@ -174,30 +149,19 @@ if __name__ == "__main__":
     try:
 
         main(
-            samples=snakemake.params.samples,
-            contig_stats=snakemake.input.contig_stats,
-            gene_tables=snakemake.input.gene_tables,
-            mapping_logs=snakemake.input.mapping_logs,
+            combined_stats=snakemake.input.combined_contig_stats
             report_out=snakemake.output.report,
-            combined_stats=snakemake.output.combined_contig_stats
+
         )
 
     except NameError:
         import argparse
 
         p = argparse.ArgumentParser()
-        p.add_argument("--samples", nargs="+")
-        p.add_argument("--contig-stats", nargs="+")
-        p.add_argument("--gene-tables", nargs="+")
-        p.add_argument("--mapping-logs", nargs="+")
         p.add_argument("--report-out")
         p.add_argument("--combined-stats")
         args = p.parse_args()
         main(
-            args.samples,
-            args.contig_stats,
-            args.gene_tables,
-            args.mapping_logs,
-            args.report_out,
             args.combined_stats,
+            args.report_out,
         )

--- a/atlas/report/bin_report.py
+++ b/atlas/report/bin_report.py
@@ -19,18 +19,13 @@ sys.path.append(os.path.join(atlas_dir,'scripts'))
 from utils.parsers_checkm import read_checkm_output
 
 
-def main(samples, completeness_files, taxonomy_files, report_out, bin_table):
-    sample_data = {}
+def main(report_out, bin_table):
+
     div = {}
 
-    df= pd.DataFrame()
+    df= pd.read_csv(bin_table,sep='\t',index_col=0)
 
-    for i,sample in enumerate(samples):
-        sample_data= read_checkm_output(taxonomy_table=taxonomy_files[i],
-                                        completness_table=completeness_files[i])
-        sample_data['Sample']= sample
 
-        df= df.append(sample_data)
 
 
     df.to_csv(bin_table,sep='\t')
@@ -142,9 +137,6 @@ if __name__ == "__main__":
 
     try:
         main(
-            samples=snakemake.params.samples,
-            taxonomy_files=snakemake.input.taxonomy_files,
-            completeness_files=snakemake.input.completeness_files,
             report_out=snakemake.output.report,
             bin_table=snakemake.output.bin_table
         )
@@ -152,12 +144,9 @@ if __name__ == "__main__":
     except NameError:
         import argparse
         p = argparse.ArgumentParser()
-        p.add_argument("--samples", nargs="+")
-        p.add_argument("--completeness", nargs="+")
-        p.add_argument("--taxonomy", nargs="+")
         p.add_argument("--report-out")
         p.add_argument("--bin-table")
         args = p.parse_args()
         main(
-            args.samples, args.completeness, args.taxonomy, args.report_out, args.bin_table
+            args.report_out, args.bin_table
         )

--- a/atlas/report/bin_report.py
+++ b/atlas/report/bin_report.py
@@ -19,7 +19,7 @@ sys.path.append(os.path.join(atlas_dir,'scripts'))
 from utils.parsers_checkm import read_checkm_output
 
 
-def main(report_out, bin_table):
+def main( bin_table,report_out):
 
     div = {}
 
@@ -137,8 +137,9 @@ if __name__ == "__main__":
 
     try:
         main(
+            bin_table=snakemake.input.bin_table
             report_out=snakemake.output.report,
-            bin_table=snakemake.output.bin_table
+
         )
 
     except NameError:
@@ -148,5 +149,5 @@ if __name__ == "__main__":
         p.add_argument("--bin-table")
         args = p.parse_args()
         main(
-            args.report_out, args.bin_table
+             args.bin_table,args.report_out
         )

--- a/atlas/report/dummy_report.py
+++ b/atlas/report/dummy_report.py
@@ -1,0 +1,54 @@
+import os, sys, stat
+log=open(snakemake.log[0],"w")
+sys.stderr= log
+sys.stdout= log
+
+import pandas as pd
+from snakemake.utils import report
+
+
+
+def main( input_files,report_out):
+
+
+input_files= '\n'.join(input_files)
+
+
+    report_str = """
+
+
+=============================================================
+ATLAS_ - Dummy Report
+=============================================================
+
+In this alpha version of atlas the repoprts don't work properly.
+I hope they will be available soon.
+
+
+I protected all input files so they don't get deleted and you will be able to re-create the reports onece the beta version is out.
+
+Input files for this report:
+{input_files}
+
+
+
+"""
+    report(report_str, report_out, stylesheet=os.path.join(atlas_dir,'report', "report.css"))
+
+
+
+
+if __name__ == "__main__":
+
+    input_files =[]
+    for file in snakemake.input:
+
+        prrint(f"protect file {file}")
+        current_file_status = stat.S_IMODE(os.lstat(file).st_mode)
+        os.chmod(file, current_file_status & ~stat.S_IEXEC)
+        input_files.append(file)
+
+    main(
+        report_out=snakemake.output.report,
+        input_files= input_files
+    )

--- a/atlas/report/qc_report.py
+++ b/atlas/report/qc_report.py
@@ -1,15 +1,20 @@
 import os,sys
-f = open(os.devnull, 'w'); sys.stdout = f # block cufflinks to plot strange code
-from cufflinks import iplot
 log=open(snakemake.log[0],"w")
 sys.stderr= log
 sys.stdout= log
 
 import numpy as np
 import pandas as pd
-import plotly.graph_objs as go
+
+pd.options.plotting.backend = "plotly"
+
+from plotly.subplots import make_subplots
+import plotly.graph_objects as go
+from plotly import offline
+
+
+
 import zipfile
-from plotly import offline, tools
 from snakemake.utils import report
 
 
@@ -53,7 +58,7 @@ def get_pe_read_quality_plot(df,quality_range,colorscale='Viridis', **kwargs):
     N= len(df["mean_1"].columns)
     c= ['hsl('+str(h)+',50%'+',50%)' for h in np.linspace(0, 360, N+1)]
 
-    fig = tools.make_subplots(rows=1, cols=2, shared_yaxes=True)
+    fig = make_subplots(rows=1, cols=2, shared_yaxes=True)
 
     for i,sample in enumerate(df["mean_1"].columns):
         fig.append_trace(dict(x= df.index,
@@ -88,11 +93,10 @@ def get_pe_read_quality_plot(df,quality_range,colorscale='Viridis', **kwargs):
     #
     # df1 = df[["mean_1", "mean_2"]]
     # return offline.plot(
-    #     df1.iplot(
+    #     df1.plot(
     #         subplots=True,
     #         shape=(1, 2),
     #         shared_yaxes=True,
-    #         asFigure=True,
     #         kind="line",
     #         layout = go.Layout(
     #             yaxis = dict(range=quality_range, autorange=True, title="Quality score"),
@@ -110,8 +114,7 @@ def get_pe_read_quality_plot(df,quality_range,colorscale='Viridis', **kwargs):
 
 def draw_se_read_quality(df,quality_range,**kwargs):
     return offline.plot(
-        df.iplot(
-            asFigure=True,
+        df.plot(
             kind="line",
             layout = go.Layout(
                 yaxis = dict(range=quality_range, autorange=True, title="Average quality score"),
@@ -138,8 +141,7 @@ def main(report_out, read_counts,zipfiles_QC, min_quality,zipfiles_raw=None):
             data.drop('clean',axis=1,inplace=True)
 
         div[variable] = offline.plot(
-                data.iplot(
-                    asFigure=True,
+                data.plot(
                     kind='bar',
                     xTitle='Samples',
                     yTitle=variable.replace('_', ' '),

--- a/atlas/rules/assemble.snakefile
+++ b/atlas/rules/assemble.snakefile
@@ -816,8 +816,9 @@ rule get_contigs_from_gene_names:
 
 
 
-localrules: build_assembly_report
-rule build_assembly_report:
+localrules: build_assembly_report, combine_contig_stats
+
+rule combined_contig_stats:
     input:
         contig_stats = expand("{sample}/assembly/contig_stats/final_contig_stats.txt", sample=SAMPLES),
         gene_tables = expand("{sample}/annotation/predicted_genes/{sample}.tsv", sample=SAMPLES),
@@ -825,13 +826,22 @@ rule build_assembly_report:
         # mapping logs will be incomplete unless we wait on alignment to finish
         bams = expand("{sample}/sequence_alignment/{sample}.bam", sample=SAMPLES)
     output:
-        report = "reports/assembly_report.html",
         combined_contig_stats = 'stats/combined_contig_stats.tsv'
     params:
         samples = SAMPLES
+    log:
+        "logs/assembly/combine_contig_stats.log"
+    script:
+        "../scripts/combine_contig_stats.py"
+
+rule build_assembly_report:
+    input:
+        combined_contig_stats = 'stats/combined_contig_stats.tsv'
+    output:
+        report = "reports/assembly_report.html",
     conda:
         "%s/report.yaml" % CONDAENV
     log:
         "logs/assembly/report.log"
     script:
-        "../report/bin_report.py" #"../report/assembly_report.py"
+        "../report/dummy_report.py" #"../report/assembly_report.py"

--- a/atlas/rules/assemble.snakefile
+++ b/atlas/rules/assemble.snakefile
@@ -834,4 +834,4 @@ rule build_assembly_report:
     log:
         "logs/assembly/report.log"
     script:
-        "../report/assembly_report.py"
+        "../report/bin_report.py" #"../report/assembly_report.py"

--- a/atlas/rules/assemble.snakefile
+++ b/atlas/rules/assemble.snakefile
@@ -665,7 +665,7 @@ ruleorder: bam_2_sam_contigs > convert_sam_to_bam
 
 rule convert_sam_to_bam:
     input:
-        "{file}.fresh.sam"
+        "{file}.sam"
     output:
         bam="{file}.bam",
         sam=temp("{file}.forpileup.sam"),

--- a/atlas/rules/binning.snakefile
+++ b/atlas/rules/binning.snakefile
@@ -485,7 +485,7 @@ rule combine_bin_stats:
     params:
         samples = SAMPLES,
     log:
-        "logs/binning/report_{binner}.log"
+        "logs/binning/combine_stats_{binner}.log"
     script:
         "../scripts/combine_bin_stats.py"
 

--- a/atlas/rules/binning.snakefile
+++ b/atlas/rules/binning.snakefile
@@ -501,7 +501,7 @@ rule build_bin_report:
     log:
         "logs/binning/report_{binner}.log"
     script:
-        "../report/bin_report.py"
+        "../report/dummy_report.py" #"../report/bin_report.py"
 
 localrules: get_unique_bin_ids
 rule get_unique_bin_ids:

--- a/atlas/rules/download.snakefile
+++ b/atlas/rules/download.snakefile
@@ -26,7 +26,7 @@ CHECKM_ARCHIVE = "checkm_data_v1.0.9.tar.gz"
 CAT_DIR= os.path.join(DBDIR,'CAT')
 CAT_flag_downloaded = os.path.join(CAT_DIR,'downloaded')
 EGGNOG_DIR = os.path.join(DBDIR,'EggNOGV2')
-GTDBTK_DATA_PATH=os.path.join(DBDIR,"GTDB_V05")
+GTDBTK_DATA_PATH=os.path.join(DBDIR,"GTDB_V06")
 CONDAENV = "../envs"
 
 # note: saving OG_fasta.tar.gz in order to not create secondary "success" file

--- a/atlas/rules/download.snakefile
+++ b/atlas/rules/download.snakefile
@@ -186,6 +186,8 @@ rule download_gtdb:
         "../envs/gtdbtk.yaml"
     threads:
         1
+    resources:
+        time= int(config['runtime']['default']) if 'runtime' in config else 5 
     shell:
         "GTDBTK_DATA_PATH={GTDBTK_DATA_PATH} ;  "
         "download-db.sh ;"

--- a/atlas/rules/genecatalog.snakefile
+++ b/atlas/rules/genecatalog.snakefile
@@ -465,7 +465,7 @@ rule eggNOG_annotation:
     threads:
         config.get("threads", 1)
     resources:
-        mem=20
+        mem=  2*config["simplejob_mem"] + (37 if config['eggNOG_use_virtual_disk'] else 0)
     shadow:
         "minimal"
     conda:

--- a/atlas/rules/genomes.smk
+++ b/atlas/rules/genomes.smk
@@ -334,31 +334,12 @@ rule align_reads_to_MAGs:
             2> {log}
         """
 
-ruleorder: bam_2_sam_MAGs > align_reads_to_MAGs
-rule bam_2_sam_MAGs:
-    input:
-        "genomes/alignments/{sample}.bam"
-    output:
-        temp("genomes/alignments/{sample}.sam")
-    threads:
-        config['threads']
-    resources:
-        mem = config["mem"],
-    shadow:
-        "shallow"
-    conda:
-        "%s/required_packages.yaml" % CONDAENV
-    shell:
-        """
-        reformat.sh in={input} out={output} sam=1.3
-        """
 
 
 
 rule pileup_MAGs:
     input:
         sam = "genomes/alignments/{sample}.sam",
-        #bam = "genomes/alignments/{sample}.bam" # to store it
     output:
         basecov = temp("genomes/alignments/{sample}_base_coverage.txt.gz"),
         covhist = temp("genomes/alignments/{sample}_coverage_histogram.txt"),

--- a/atlas/rules/get_fasta_of_bins.py
+++ b/atlas/rules/get_fasta_of_bins.py
@@ -42,20 +42,22 @@ def get_fasta_of_bins(cluster_attribution, contigs, out_folder):
 
 
 if __name__ == "__main__":
-    try:
-        log=open(snakemake.log[0],"w")
-        sys.stderr= log
-        sys.stdout= log
-        
-        get_fasta_of_bins(
-            snakemake.input.cluster_attribution,
-            snakemake.input.contigs,
-            snakemake.output[0],
-        )
-    except NameError:
+
+    if 'snakemake' not in globals():
+
         p = argparse.ArgumentParser()
         p.add_argument("--cluster-attribution")
         p.add_argument("--contigs")
         p.add_argument("--out-folder")
         args = vars(p.parse_args())
         get_fasta_of_bins(**args)
+    else:
+
+        with open(snakemake.log[0],"w") as log:
+            sys.stderr= sys.stdout = log
+
+            get_fasta_of_bins(
+                snakemake.input.cluster_attribution,
+                snakemake.input.contigs,
+                snakemake.output[0],
+            )

--- a/atlas/rules/qc.snakefile
+++ b/atlas/rules/qc.snakefile
@@ -618,4 +618,4 @@ rule build_qc_report:
     conda:
         "%s/report.yaml" % CONDAENV
     script:
-         "../report/bin_report.py" #"../report/qc_report.py"
+         "../report/dummy_report.py" #"../report/qc_report.py"

--- a/atlas/rules/qc.snakefile
+++ b/atlas/rules/qc.snakefile
@@ -618,4 +618,4 @@ rule build_qc_report:
     conda:
         "%s/report.yaml" % CONDAENV
     script:
-         "../report/qc_report.py"
+         "../report/bin_report.py" #"../report/qc_report.py"

--- a/atlas/scripts/combine_bin_stats.py
+++ b/atlas/scripts/combine_bin_stats.py
@@ -12,7 +12,7 @@ sys.path.append(os.path.join(atlas_dir,'scripts'))
 from utils.parsers_checkm import read_checkm_output
 
 
-def main(samples, completeness_files, taxonomy_files, report_out, bin_table):
+def main(samples, completeness_files, taxonomy_files, bin_table):
     sample_data = {}
     div = {}
 

--- a/atlas/scripts/combine_bin_stats.py
+++ b/atlas/scripts/combine_bin_stats.py
@@ -1,0 +1,40 @@
+import os,sys
+log=open(snakemake.log[0],"w")
+sys.stderr= log
+sys.stdout= log
+
+import pandas as pd
+from snakemake.utils import report
+
+
+atlas_dir= os.path.abspath(os.path.join(os.path.dirname(__file__),'..'))
+sys.path.append(os.path.join(atlas_dir,'scripts'))
+from utils.parsers_checkm import read_checkm_output
+
+
+def main(samples, completeness_files, taxonomy_files, report_out, bin_table):
+    sample_data = {}
+    div = {}
+
+    df= pd.DataFrame()
+
+    for i,sample in enumerate(samples):
+        sample_data= read_checkm_output(taxonomy_table=taxonomy_files[i],
+                                        completness_table=completeness_files[i])
+        sample_data['Sample']= sample
+
+        df= df.append(sample_data)
+
+
+    df.to_csv(bin_table,sep='\t')
+
+
+if __name__ == "__main__":
+
+
+    main(
+        samples=snakemake.params.samples,
+        taxonomy_files=snakemake.input.taxonomy_files,
+        completeness_files=snakemake.input.completeness_files,
+        bin_table=snakemake.output.bin_table
+    )

--- a/atlas/scripts/combine_contig_stats.py
+++ b/atlas/scripts/combine_contig_stats.py
@@ -1,0 +1,84 @@
+import os,sys
+import logging, traceback
+logging.basicConfig(filename=snakemake.log[0],
+                    level=logging.INFO,
+                    format='%(asctime)s %(message)s',
+                    datefmt='%Y-%m-%d %H:%M:%S',
+                    )
+def handle_exception(exc_type, exc_value, exc_traceback):
+    if issubclass(exc_type, KeyboardInterrupt):
+        sys.__excepthook__(exc_type, exc_value, exc_traceback)
+        return
+
+    logger.error(''.join(["Uncaught exception: ",
+                         *traceback.format_exception(exc_type, exc_value, exc_traceback)
+                         ])
+                 )
+# Install exception handler
+sys.excepthook = handle_exception
+
+
+
+import pandas as pd
+from utils.parsers_bbmap import parse_bbmap_log_file
+
+
+
+
+def parse_map_stats(sample_data, out_tsv):
+    stats_df = pd.DataFrame()
+    for sample in sample_data.keys():
+        df = pd.read_csv(sample_data[sample]["contig_stats"],sep='\t')
+        assert df.shape[0] == 1, "Assumed only one row in file {}; found {}".format(
+            sample_data[sample]["contig_stats"], df.iloc[0]
+        )
+        df = df.iloc[0]
+        df.name = sample
+        genes_df = pd.read_csv(sample_data[sample]["gene_table"], index_col=0,sep='\t')
+        df["N_Predicted_Genes"] = genes_df.shape[0]
+        used_reads,mapped_reads= parse_bbmap_log_file(sample_data[sample]["mapping_log"])
+        df["Assembled_Reads"] = mapped_reads
+        df["Percent_Assembled_Reads"] = mapped_reads/used_reads *100
+
+        stats_df = stats_df.append(df)
+    stats_df = stats_df.loc[:, ~ stats_df.columns.str.startswith("scaf_")]
+    stats_df.columns = stats_df.columns.str.replace("ctg_", "")
+    stats_df.to_csv(out_tsv, sep="\t")
+    return stats_df
+
+
+def main(samples, contig_stats, gene_tables, mapping_logs, combined_stats):
+    sample_data = {}
+    for sample in samples:
+        sample_data[sample] = {}
+        for c_stat in contig_stats:
+            # underscore version was for simplified local testing
+            # if "%s_" % sample in c_stat:
+            if "%s/" % sample in c_stat:
+                sample_data[sample]["contig_stats"] = c_stat
+        for g_table in gene_tables:
+            # if "%s_" % sample in g_table:
+            if "%s/" % sample in g_table:
+                sample_data[sample]["gene_table"] = g_table
+        for mapping_log in mapping_logs:
+            # if "%s_" % sample in mapping_log:
+            if "%s/" % sample in mapping_log:
+                sample_data[sample]["mapping_log"] = mapping_log
+
+    parse_map_stats(sample_data, combined_stats)
+
+
+
+
+
+
+if __name__ == "__main__":
+
+
+    main(
+        samples=snakemake.params.samples,
+        contig_stats=snakemake.input.contig_stats,
+        gene_tables=snakemake.input.gene_tables,
+        mapping_logs=snakemake.input.mapping_logs,
+        combined_stats=snakemake.output.combined_contig_stats
+    )

--- a/atlas/scripts/root_tree.py
+++ b/atlas/scripts/root_tree.py
@@ -7,5 +7,6 @@ with open(snakemake.log[0], "w") as log:
 
     T= ete3.Tree(snakemake.input.tree,quoted_node_names=True,format=1)
     T.unroot()
-    T.set_outgroup(T.get_midpoint_outgroup())
+    if len(T) > 2:
+        T.set_outgroup(T.get_midpoint_outgroup())
     T.write(outfile=snakemake.output.tree)

--- a/atlas/scripts/root_tree.py
+++ b/atlas/scripts/root_tree.py
@@ -1,10 +1,11 @@
 import sys
 import ete3
 
+with open(snakemake.log[0], "w") as log:
+    sys.stderr = sys.stdout = log
 
-sys.stdout= open(snakemake.log[0],"w")
 
-T= ete3.Tree(snakemake.input.tree,quoted_node_names=True,format=1)
-T.unroot()
-T.set_outgroup(T.get_midpoint_outgroup())
-T.write(outfile=snakemake.output.tree)
+    T= ete3.Tree(snakemake.input.tree,quoted_node_names=True,format=1)
+    T.unroot()
+    T.set_outgroup(T.get_midpoint_outgroup())
+    T.write(outfile=snakemake.output.tree)

--- a/atlas/template_config.yaml
+++ b/atlas/template_config.yaml
@@ -107,7 +107,7 @@ megahit_preset: default
 # Spades
 #------------
 spades_skip_BayesHammer: true
-spades_use_scaffolds: false # use contigs
+spades_use_scaffolds: true # if false use contigs
 #Comma-separated list of k-mer sizes to be used (all values must be odd, less than 128 and listed in ascending order).
 spades_k: auto
 spades_preset: meta    # meta, ,normal, rna  single end libraries doesn't work for metaspades

--- a/atlasenv.yml
+++ b/atlasenv.yml
@@ -4,7 +4,8 @@ channels:
   - defaults
 dependencies:
   - python=3.6
-  - snakemake=5.9.1
+  - snakemake
+  - mamba
   - pandas<1 # needs to be < 0.24 otherwise series are printed with header
   - bbmap=37.78
   - click=7

--- a/atlasenv.yml
+++ b/atlasenv.yml
@@ -5,9 +5,9 @@ channels:
 dependencies:
   - python=3.7
   - mamba
-  - snakemake>=5.30, <6
-  - pandas>1, <2
   - bbmap
+  - snakemake=6.1
+  - pandas>1 
   - click=7
   - ruamel.yaml=0.15.99 # needs to be explicit
   - biopython=1.74

--- a/atlasenv.yml
+++ b/atlasenv.yml
@@ -3,11 +3,11 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - python=3.6
-  - snakemake
+  - python=3.7
   - mamba
-  - pandas<1 # needs to be < 0.24 otherwise series are printed with header
-  - bbmap=37.78
+  - snakemake>=5.30, <6
+  - pandas>1, <2
+  - bbmap
   - click=7
   - ruamel.yaml=0.15.99 # needs to be explicit
   - biopython=1.74


### PR DESCRIPTION
This fixes a long-standing problem with a circular dependency in the sam/bam conversion. 

This means the fix allows to use the up to date snakemake with all advantages.

First and foremost: `--conda-frontend mamba` for fast installation of the environments.
Fix #348 #332 #318

Additional changes to come:
- [x] use mamba as default frontend
- [ ] integrate the atlas_analyze extension into atlas
- [ ] qc report loging
- [ ] Create report

