### PR TITLE
independent run of semibin

### DIFF
--- a/atlas/rules/semibin.smk
+++ b/atlas/rules/semibin.smk
@@ -21,7 +21,7 @@ rule semibin_download_gtdb:
 rule semibin_predict_taxonomy:
     input:
         "{sample}/{sample}_contigs.fasta",
-        fasta=ancient("Cobinning/filtered_contigs/{sample}.fasta"),
+        fasta=rules.filter_contigs.output,
         db=SEMIBIN_DATA_PATH,
     output:
         "Cobinning/SemiBin/{sample}/cannot/cannot_bin.txt",
@@ -87,7 +87,7 @@ rule semibin_generate_data_multi:
 rule semibin_train:
     input:
         "{sample}/{sample}_contigs.fasta",
-        fasta=ancient("Cobinning/filtered_contigs/{sample}.fasta"),
+        fasta=rules.filter_contigs.output,
         bams=expand(rules.sort_bam.output, sample=SAMPLES),
         data="Cobinning/SemiBin/samples/{sample}/data.csv",
         data_split="Cobinning/SemiBin/samples/{sample}/data_split.csv",
@@ -124,7 +124,7 @@ rule semibin_train:
 rule run_semibin:
     input:
         "{sample}/{sample}_contigs.fasta",
-        fasta=ancient("Cobinning/filtered_contigs/{sample}.fasta"),
+        fasta=rules.filter_contigs.output,
         bams=expand(rules.sort_bam.output, sample=SAMPLES),
         data="Cobinning/SemiBin/samples/{sample}/data.csv",
         model=rules.semibin_train.output[0],

--- a/atlas/rules/semibin.smk
+++ b/atlas/rules/semibin.smk
@@ -142,7 +142,7 @@ rule run_semibin:
         "logs/benchmarks/semibin/bin/{sample}.tsv"
     params:
         output_dir="Cobinning/SemiBin/{sample}/",
-        min_bin_kbs=config["cobining_min_bin_size"] / 1000,
+        min_bin_kbs=int(config["cobining_min_bin_size"] / 1000),
         extra=config["semibin_options"],
     shell:
         "SemiBin bin "


### PR DESCRIPTION
@SilasK  I have accomplished a test run of `semibin`, but rely on existence of `Cobinning/filtered_contigs/{sample}.fasta`. Small bug fix:

1.         " --minfasta-kbs {params.min_bin_kbs}"
it seems to only accept integer type. I am not sure if you met this.

2.         fasta=ancient("Cobinning/filtered_contigs/{sample}.fasta"),
The `ancient` flag in `semibin.smk` seems to be in conflict in the `temp` flag in `cobinning.smk`
I couldn't run `semibin` independently if I didn't keep the `filtered_contig` output from `cobinning.smk`.
I tried it in new working directory, directly run `atlas run None semibin --profile cluster`. It works fine if specifying `--dry-run`. But it fails in a real run.
```
Traceback (most recent call last):
  File "/home/projects/cu_10168/people/yanhui/bin/miniconda3/envs/atlas-dev/lib/python3.8/site-packages/snakemak
e/__init__.py", line 699, in snakemake
    success = workflow.execute(
  File "/home/projects/cu_10168/people/yanhui/bin/miniconda3/envs/atlas-dev/lib/python3.8/site-packages/snakemak
e/workflow.py", line 1056, in execute
    success = scheduler.schedule()
  File "/home/projects/cu_10168/people/yanhui/bin/miniconda3/envs/atlas-dev/lib/python3.8/site-packages/snakemak
e/scheduler.py", line 477, in schedule
    run = self.job_selector(needrun)
  File "/home/projects/cu_10168/people/yanhui/bin/miniconda3/envs/atlas-dev/lib/python3.8/site-packages/snakemak
e/scheduler.py", line 816, in job_selector_greedy
    c = list(map(self.job_reward, jobs))  # job rewards
  File "/home/projects/cu_10168/people/yanhui/bin/miniconda3/envs/atlas-dev/lib/python3.8/site-packages/snakemak
e/scheduler.py", line 898, in job_reward
    temp_size = self.dag.temp_size(job)
  File "/home/projects/cu_10168/people/yanhui/bin/miniconda3/envs/atlas-dev/lib/python3.8/site-packages/snakemak
e/dag.py", line 597, in temp_size
    return sum(f.size for f in self.temp_input(job))
  File "/home/projects/cu_10168/people/yanhui/bin/miniconda3/envs/atlas-dev/lib/python3.8/site-packages/snakemak
e/dag.py", line 597, in <genexpr>
    return sum(f.size for f in self.temp_input(job))
  File "/home/projects/cu_10168/people/yanhui/bin/miniconda3/envs/atlas-dev/lib/python3.8/site-packages/snakemak
e/io.py", line 251, in wrapper
    return func(self, *args, **kwargs)
  File "/home/projects/cu_10168/people/yanhui/bin/miniconda3/envs/atlas-dev/lib/python3.8/site-packages/snakemak
e/io.py", line 266, in wrapper
    return func(self, *args, **kwargs)
  File "/home/projects/cu_10168/people/yanhui/bin/miniconda3/envs/atlas-dev/lib/python3.8/site-packages/snakemak
e/io.py", line 569, in size
    return self.size_local
  File "/home/projects/cu_10168/people/yanhui/bin/miniconda3/envs/atlas-dev/lib/python3.8/site-packages/snakemak
e/io.py", line 574, in size_local
    self.check_broken_symlink()
  File "/home/projects/cu_10168/people/yanhui/bin/miniconda3/envs/atlas-dev/lib/python3.8/site-packages/snakemak
e/io.py", line 579, in check_broken_symlink
    if not self.exists_local and os.lstat(self.file):
FileNotFoundError: [Errno 2] No such file or directory: 'Cobinning/filtered_contigs/sample1.fasta'
```
It's wired... but probably related with https://github.com/snakemake/snakemake/issues/221
I kept the `temp` flag for `filtered_contigs` output in `semibin.smk`. And it works.
It shall/may not change your phylosiphy of avoiding recreation of files.

