### PR TITLE
eggnog_proteins.dmnd needed for tmpfs

### DIFF
--- a/atlas/rules/genecatalog.smk
+++ b/atlas/rules/genecatalog.smk
@@ -401,6 +401,7 @@ rule eggNOG_annotation:
         if [ {params.copyto_shm} == "t" ] ;
         then
             cp {EGGNOG_DIR}/eggnog.db {params.data_dir}/eggnog.db 2> {log}
+            cp {EGGNOG_DIR}/eggnog_proteins.dmnd {params.data_dir}/eggnog_proteins.dmnd 2>> {log}
         fi
 
         emapper.py --annotate_hits_table {input.seed} --no_file_comments \


### PR DESCRIPTION
Placing eggnog db in memory is unbeliveably fast for the annotations step. 👍 
The `eggnog_proteins.dmnd` seems also to be included. I need this for our clusters, also https://github.com/eggnogdb/eggnog-mapper/issues/277#issuecomment-783365657

A flaw for putting the eggnog db in memory:
The `cp` will cause crashes if two/more `qsub` jobs run in the same computing node. In this case, the jobs use the same `/dev/shm`, and the `cp` (except in the first job) will collapse if the files are already there.
It's a bit tricky to solve it. You can't re-write the db file, if one job's using it. Also, the jobs in one node/cluster didn't finish in the same time. 

Maybe just leave it as it is. At least, it's easily controlled to place annotation rule in separate nodes if we choose approriate number of threads. Or repeat the pipeline several times.


