### PR TITLE
add "import logging" to "atlas/workflow/rules/assemble.smk"

### DIFF
--- a/atlas/workflow/rules/assemble.smk
+++ b/atlas/workflow/rules/assemble.smk
@@ -3,6 +3,7 @@ import re
 import sys
 from glob import glob
 from snakemake.utils import report
+import logging
 import warnings
 from copy import deepcopy
 


### PR DESCRIPTION
The command "atlas run all" issued an error due to the absence of module import. 
Added relevant import. 