### PR TITLE
GTDB-tk requires rule `extract_gtdb` to run first

### DIFF
--- a/atlas/workflow/rules/download.smk
+++ b/atlas/workflow/rules/download.smk
@@ -196,11 +196,11 @@ rule extract_gtdb:
     resources:
         time=int(config.get("runtime", {"long": 10})["long"]),
     log:
-        "logs/download/gtdbtk.log",
+        "logs/download/gtdbtk_untar.log",
     shell:
-        ' tar -xzvf {input} -C "{GTDBTK_DATA_PATH}" --strip 1 2> {log} '
-        ' echo "Set the GTDBTK_DATA_PATH environment variable to {GTDBTK_DATA_PATH} " >> {log}'
-        " conda env config vars set GTDBTK_DATA_PATH={GTDBTK_DATA_PATH} "
+        'tar -xzvf {input} -C "{GTDBTK_DATA_PATH}" --strip 1 2> {log}; '
+        'echo "Set the GTDBTK_DATA_PATH environment variable to {GTDBTK_DATA_PATH} " >> {log}; '
+        "conda env config vars set GTDBTK_DATA_PATH={GTDBTK_DATA_PATH} "
 
 
 onsuccess:

--- a/atlas/workflow/rules/gtdbtk.smk
+++ b/atlas/workflow/rules/gtdbtk.smk
@@ -3,7 +3,7 @@ gtdb_dir = "genomes/taxonomy/gtdb"
 
 rule identify:
     input:
-        flag=rules.download_gtdb.output,
+        flag=rules.extract_gtdb.output,
         genes_flag="genomes/annotations/genes/predicted",
     output:
         directory(f"{gtdb_dir}/identify"),


### PR DESCRIPTION
The GTDB-data download was split into two rules with commit 591446d181d6620efc79e83649d7a7865bbdd415
1. Download (rule `download_gtdb`)
2. Unpackung of archive (rule `extract_gtdb`)

The rule `identify` now needs to depend on the output of the unpacking step.