### PR TITLE
Specify bbsplit tool-specific memory parameter

### DIFF
--- a/atlas/workflow/rules/bbsplit.smk
+++ b/atlas/workflow/rules/bbsplit.smk
@@ -70,6 +70,7 @@ rule bbsplit:
         " refstats={output.refstats} "
         " covstats={output.covstats} "
         " bincov={output.bincov} "
+        " -Xmx{resources.java_mem}G "
         " 2> {log} "
 
 


### PR DESCRIPTION
Otherwise, `bbsplit.sh` will automatically detect and allocate available memory, which could exceed memory requested for the cluster execution.