### PR TITLE
Update semibin to v1.3

### DIFF
--- a/atlas/workflow/envs/semibin.yaml
+++ b/atlas/workflow/envs/semibin.yaml
@@ -3,5 +3,6 @@ channels:
   - bioconda
   - defaults
 dependencies:
+  - python>=3.8, <3.11
   - semibin=1.3
   - biopython

--- a/atlas/workflow/envs/semibin.yaml
+++ b/atlas/workflow/envs/semibin.yaml
@@ -3,5 +3,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - python>=3.8, <3.11
-  - semibin=0.5
+  - semibin=1.3

--- a/atlas/workflow/envs/semibin.yaml
+++ b/atlas/workflow/envs/semibin.yaml
@@ -4,3 +4,4 @@ channels:
   - defaults
 dependencies:
   - semibin=1.3
+  - biopython

--- a/atlas/workflow/rules/semibin.smk
+++ b/atlas/workflow/rules/semibin.smk
@@ -25,7 +25,7 @@ rule run_semibin:
         " --input-bam {input.bams} "
         " --output {params.output_dir} "
         " --threads {threads} "
-	" --training-mode=self "
+	" --training-type=self "
         " --minfasta-kbs {params.min_bin_kbs}"
         " {params.extra} "
         " 2> {log}"

--- a/atlas/workflow/rules/semibin.smk
+++ b/atlas/workflow/rules/semibin.smk
@@ -1,8 +1,76 @@
+
+rule semibin_generate_data_multi:
+    input:
+        fasta=rules.combine_contigs.output,
+        bams=expand(rules.sort_bam.output, sample=SAMPLES),
+    output:
+        expand(
+            "Cobinning/SemiBin/samples/{sample}/{files}",
+            sample=SAMPLES,
+            files=["data.csv", "data_split.csv"],
+        ),
+    conda:
+        "../envs/semibin.yaml"
+    threads: config["threads"]
+    resources:
+        mem=config["mem"],
+        time=config["runtime"]["default"],
+    log:
+        "logs/semibin/generate_data_multi.log",
+    benchmark:
+        "logs/benchmarks/semibin/generate_data_multi.tsv"
+    params:
+        output_dir="Cobinning/SemiBin",
+        separator=config["cobinning_separator"],
+    shell:
+        "SemiBin generate_sequence_features_multi"
+        " --input-fasta {input.fasta} "
+        " --input-bam {input.bams} "
+        " --output {params.output_dir} "
+        " --threads {threads} "
+        " --separator {params.separator} "
+        " 2> {log}"
+
+
+rule semibin_train:
+    input:
+        "{sample}/{sample}_contigs.fasta",
+        fasta=rules.filter_contigs.output,
+        bams=expand(rules.sort_bam.output, sample=SAMPLES),
+        data="Cobinning/SemiBin/samples/{sample}/data.csv",
+        data_split="Cobinning/SemiBin/samples/{sample}/data_split.csv",
+    output:
+        "Cobinning/SemiBin/{sample}/model.h5",
+    conda:
+        "../envs/semibin.yaml"
+    threads: config["threads"]
+    resources:
+        mem=config["mem"],
+        time=config["runtime"]["default"],
+    log:
+        "logs/semibin/train/{sample}.log",
+    benchmark:
+        "logs/benchmarks/semibin/train/{sample}.tsv"
+    params:
+        output_dir=lambda wc, output: os.path.dirname(output[0]),
+        extra=" --epochs 20 --mode single ",
+    shell:
+        "SemiBin train_self "
+        " --output {params.output_dir} "
+        " --threads {threads} "
+        " --data {input.data} "
+        " --data-split {input.data_split} "
+        " {params.extra} "
+        " 2> {log}"
+
+
 rule run_semibin:
     input:
         "{sample}/{sample}_contigs.fasta",
         fasta=rules.filter_contigs.output,
         bams=expand(rules.sort_bam.output, sample=SAMPLES),
+        data="Cobinning/SemiBin/samples/{sample}/data.csv",
+        model=rules.semibin_train.output[0],
     output:
         directory("Cobinning/SemiBin/{sample}/output_recluster_bins/"),
     conda:
@@ -20,12 +88,12 @@ rule run_semibin:
         min_bin_kbs=int(config["cobining_min_bin_size"] / 1000),
         extra=config["semibin_options"],
     shell:
-        "SemiBin single_easy_bin "
+        "SemiBin bin "
         " --input-fasta {input.fasta} "
-        " --input-bam {input.bams} "
         " --output {params.output_dir} "
         " --threads {threads} "
-	" --training-type=self "
+        " --data {input.data} "
+        " --model {input.model} "
         " --minfasta-kbs {params.min_bin_kbs}"
         " {params.extra} "
         " 2> {log}"

--- a/atlas/workflow/rules/semibin.smk
+++ b/atlas/workflow/rules/semibin.smk
@@ -1,135 +1,8 @@
-SEMIBIN_DATA_PATH = os.path.join(DBDIR, "SemiBin_GTDB")
-
-
-localrules:
-    semibin_download_gtdb,
-
-
-rule semibin_download_gtdb:
-    output:
-        directory(SEMIBIN_DATA_PATH),
-    log:
-        "logs/download/Semibin.txt",
-    conda:
-        "../envs/semibin.yaml"
-    threads: 1
-    shell:
-        "SemiBin download_GTDB --reference-db {output} 2> {log}"
-        # Semibin 0.2 has the following error https:/github.com/BigDataBiology/SemiBin/issues/31
-
-
-rule semibin_predict_taxonomy:
-    input:
-        "{sample}/{sample}_contigs.fasta",
-        fasta=rules.filter_contigs.output,
-        db=SEMIBIN_DATA_PATH,
-    output:
-        "Cobinning/SemiBin/{sample}/cannot/cannot_bin.txt",
-        "Cobinning/SemiBin/{sample}/mmseqs_contig_annotation/taxonomyResult.tsv",
-    conda:
-        "../envs/semibin.yaml"
-    threads: config["threads"]
-    resources:
-        mem=config["large_mem"],
-        time=config["runtime"]["default"],
-    log:
-        "logs/semibin/predict_taxonomy/{sample}.log",
-    benchmark:
-        "logs/benchmarks/semibin/predict_taxonomy/{sample}.tsv"
-    params:
-        output_dir="Cobinning/SemiBin/{sample}",
-        name=lambda wc, output: os.path.basename(output[0]).replace(".txt", ""),
-        tmp_dir=config["tmpdir"],
-    shadow:
-        "minimal"
-    shell:
-        " export TMPDIR={params.tmp_dir} &> {log} ;"
-        "SemiBin predict_taxonomy "
-        " --input-fasta {input.fasta} "
-        " --threads {threads} "
-        " --output {params.output_dir} "
-        " --cannot-name {params.name} "
-        " --reference-db {input.db}/GTDB "
-        " &>> {log} "
-
-
-rule semibin_generate_data_multi:
-    input:
-        fasta=rules.combine_contigs.output,
-        bams=expand(rules.sort_bam.output, sample=SAMPLES),
-    output:
-        expand(
-            "Cobinning/SemiBin/samples/{sample}/{files}",
-            sample=SAMPLES,
-            files=["data.csv", "data_split.csv"],
-        ),
-    conda:
-        "../envs/semibin.yaml"
-    threads: config["threads"]
-    resources:
-        mem=config["mem"],
-        time=config["runtime"]["default"],
-    log:
-        "logs/semibin/generate_data_multi.log",
-    benchmark:
-        "logs/benchmarks/semibin/generate_data_multi.tsv"
-    params:
-        output_dir="Cobinning/SemiBin",
-        separator=config["cobinning_separator"],
-    shell:
-        "SemiBin generate_data_multi "
-        " --input-fasta {input.fasta} "
-        " --input-bam {input.bams} "
-        " --output {params.output_dir} "
-        " --threads {threads} "
-        " --separator {params.separator} "
-        " 2> {log}"
-
-
-rule semibin_train:
-    input:
-        "{sample}/{sample}_contigs.fasta",
-        fasta=rules.filter_contigs.output,
-        bams=expand(rules.sort_bam.output, sample=SAMPLES),
-        data="Cobinning/SemiBin/samples/{sample}/data.csv",
-        data_split="Cobinning/SemiBin/samples/{sample}/data_split.csv",
-        cannot_link=rules.semibin_predict_taxonomy.output[0],
-    output:
-        "Cobinning/SemiBin/{sample}/model.h5",
-    conda:
-        "../envs/semibin.yaml"
-    threads: config["threads"]
-    resources:
-        mem=config["mem"],
-        time=config["runtime"]["default"],
-    log:
-        "logs/semibin/train/{sample}.log",
-    benchmark:
-        "logs/benchmarks/semibin/train/{sample}.tsv"
-    params:
-        output_dir=lambda wc, output: os.path.dirname(output[0]),
-        extra=" --epoches 20 --mode single ",
-    shell:
-        "SemiBin train "
-        " --input-fasta {input.fasta} "
-        " --input-bam {input.bams} "
-        " --output {params.output_dir} "
-        " --threads {threads} "
-        " --data {input.data} "
-        " --data-split {input.data_split} "
-        " --cannot-link {input.cannot_link} "
-        " --mode single "
-        " {params.extra} "
-        " 2> {log}"
-
-
 rule run_semibin:
     input:
         "{sample}/{sample}_contigs.fasta",
         fasta=rules.filter_contigs.output,
         bams=expand(rules.sort_bam.output, sample=SAMPLES),
-        data="Cobinning/SemiBin/samples/{sample}/data.csv",
-        model=rules.semibin_train.output[0],
     output:
         directory("Cobinning/SemiBin/{sample}/output_recluster_bins/"),
     conda:
@@ -147,13 +20,12 @@ rule run_semibin:
         min_bin_kbs=int(config["cobining_min_bin_size"] / 1000),
         extra=config["semibin_options"],
     shell:
-        "SemiBin bin "
+        "SemiBin single_easy_bin "
         " --input-fasta {input.fasta} "
         " --input-bam {input.bams} "
         " --output {params.output_dir} "
         " --threads {threads} "
-        " --data {input.data} "
-        " --model {input.model} "
+	" --training-mode=self "
         " --minfasta-kbs {params.min_bin_kbs}"
         " {params.extra} "
         " 2> {log}"
@@ -180,6 +52,3 @@ rule semibin:
     input:
         expand("Cobinning/SemiBin/{sample}/output_recluster_bins/", sample=SAMPLES),
         expand("{sample}/binning/SemiBin/cluster_attribution.tsv", sample=SAMPLES),
-
-
-# alternative to pretrained model --environment: Environment for the built-in model(human_gut/dog_gut/ocean)."

--- a/atlas/workflow/rules/semibin.smk
+++ b/atlas/workflow/rules/semibin.smk
@@ -108,6 +108,8 @@ rule parse_semibin_output:
         rules.run_semibin.output[0],
     output:
         "{sample}/binning/SemiBin/cluster_attribution.tsv",
+    conda:
+        "../envs/semibin.yaml"
     log:
         "logs/semibin/parse_output/{sample}.log",
     params:


### PR DESCRIPTION
This updates SemiBin to v1.3 and switches to self-training by default. This closes https://github.com/metagenome-atlas/atlas/issues/588

SemiBin v0.5 runtime of the `train` step on HPC node with 20 CPU:

|s                |hours:minutes:seconds|max_rss                                                            |max_vms|max_uss|max_pss|io_in |io_out|mean_load|cpu_time|
|-----------------|-----|-------------------------------------------------------------------|-------|-------|-------|------|------|---------|--------|
|4246.2376        |1:10:46|1657.34                                                            |4792.95|1651.03|1651.46|497.45|0.09  |906.11   |37477.90|

The output of the SemiBin v1.3 benchmark of the new `train_self` step on HPC node with 20 CPU:

|s                |hours:minutes:seconds|max_rss                                                            |max_vms|max_uss|max_pss|io_in |io_out|mean_load|cpu_time|
|-----------------|-----|-------------------------------------------------------------------|-------|-------|-------|------|------|---------|--------|
|3972.1639        |1:06:12|2861.91                                                            |8327.03|2857.93|2858.25|236.23|0.08  |1963.73  |78005.33|

v1.3 skips the GTDB download (~1 hour) and MMSeqs2 clustering (~20min per sample for `predict_taxonomy`) for speed gains. I have not fully evaluated the gains in terms of number of bins, completeness of bins etc. for lack of a good baseline.