### PR TITLE
Fixed error in rule combine_egg_nogg_annotations:

### DIFF
--- a/workflow/rules/genecatalog.smk
+++ b/workflow/rules/genecatalog.smk
@@ -533,6 +533,8 @@ rule combine_egg_nogg_annotations:
             del Tables
 
             combined.columns = EGGNOG_HEADER
+            combined['Seed_evalue'] = combined['Seed_evalue'].astype('bytes')
+            combined['Seed_Score'] = combined['Seed_Score'].astype('bytes')
 
             #           combined.sort_values("Gene",inplace=True)
 


### PR DESCRIPTION

``
RuleException:
ArrowTypeError in file /projects/com_perkinsd/mrasic2/myatlas/atlas/atlas/workflow/rules/genecatalog.smk, line 541:
("Expected bytes, got a 'float' object", 'Conversion failed for column Seed_Score with type object')
``

This occured with column 'Seed_evalue' and 'Seed_Score'. I was able to fix it by a simple .astype.