### PR TITLE
Improvement of offline cluster mode

### DIFF
--- a/workflow/rules/download.smk
+++ b/workflow/rules/download.smk
@@ -98,6 +98,7 @@ localrules:
     download_eggNOG_files,
     download_atlas_files,
     download_checkm_data,
+    download_gunc,
 
 
 ruleorder: download_eggNOG_files > download_atlas_files

--- a/workflow/rules/dram.smk
+++ b/workflow/rules/dram.smk
@@ -11,6 +11,11 @@ def get_dram_config(wildcards):
     return config.get("dram_config_file", f"{DBDIR}/DRAM/DRAM.config")
 
 
+localrules:
+    dram_download,
+    concat_annotations,
+
+
 rule dram_download:
     output:
         dbdir=directory(f"{DBDIR}/DRAM/db/"),
@@ -77,10 +82,6 @@ def get_all_dram(wildcards):
 
 
 DRAM_ANNOTATON_FILES = ["annotations.tsv"]
-
-
-localrules:
-    concat_annotations,
 
 
 rule concat_annotations:


### PR DESCRIPTION
- these two commits add the download of gunc and dram to local rules which avoids errors on cluster without internet access from jobs
- refers to #666 
- thanks to @Waschina 