### PR TITLE
Public init v2

### DIFF
--- a/atlas/atlas.py
+++ b/atlas/atlas.py
@@ -9,7 +9,7 @@ import click
 
 from snakemake.io import load_configfile
 from .make_config import validate_config
-from .init.atlas_init import run_init  # , run_init_sra
+from .init.atlas_init import run_init, run_init_sra
 
 from .__init__ import __version__
 
@@ -66,7 +66,7 @@ def cli(obj):
 cli.add_command(run_init)
 
 
-# cli.add_command(run_init_sra)
+cli.add_command(run_init_sra)
 
 
 def get_snakefile(file="workflow/Snakefile"):

--- a/atlas/init/atlas_init.py
+++ b/atlas/init/atlas_init.py
@@ -241,13 +241,6 @@ def run_init_sra(
     ignore_paired=False,
     overwrite=False,
 ):
-    """"""
-
-    if len(identifiers) == 0:
-        click.echo(
-            "No SRA identifiers supplied, exiting. Use --help for more information."
-        )
-        sys.exit(1)
 
     from .get_SRA_runinfo import get_runtable_from_ids
     from .parse_sra import (
@@ -279,7 +272,7 @@ def run_init_sra(
 
     # save filtered runtable
     logger.info(f"Write filtered runinfo to {runinfo_file}")
-    RunTable_filtered.to_csv(runinfo_file, sep="\t")
+    RunTable_filtered.to_csv(runinfo_file, sep=",")
 
     # validate if can be merged
     RunTable = validate_merging_runinfo(runinfo_file)

--- a/atlas/init/parse_sra.py
+++ b/atlas/init/parse_sra.py
@@ -14,7 +14,7 @@ Expected_library_values = {
 
 
 def load_and_validate_runinfo_table(path):
-    RunTable = pd.read_csv(path, sep="\t", index_col=0)
+    RunTable = pd.read_csv(path, sep=",", index_col=0)
 
     # validate sra table
     format_error = False
@@ -24,7 +24,7 @@ def load_and_validate_runinfo_table(path):
         "LibraryLayout",
         "LibrarySource",
         "LibrarySelection",
-        "LibraryStrategy",
+        #"LibraryStrategy",
         "BioSample",
     ]
     for header in Expected_headers:
@@ -72,7 +72,7 @@ def filter_runinfo(RunTable, ignore_paired=False):
                 f"Filtered out {Difference} runs"
             )
 
-    for key in ["LibrarySelection", "LibraryStrategy"]:
+    for key in ["LibrarySelection"]: #, "LibraryStrategy"]:
         Nruns_before = RunTable.shape[0]
         All_values = RunTable[key].unique()
         if any(RunTable[key] != Expected_library_values[key]):


### PR DESCRIPTION
This provides minor update to the `init-public` script that bypasses the need for the NCBI trace by instead using the SraRunTable.txt file as direct input (which can be downloaded from the [SRA website](https://www.ncbi.nlm.nih.gov/sra) via clicking the `Send to Run Selector`, followed by the `Metadata` buttons.

EDIT: Created this pull request a bit premature XD -- this isn't intended to be merged in, but rather provide a workaround to the public-init issue.