### PR TITLE
Update multiqc wrapper to newest version.

### DIFF
--- a/workflow/rules/genomes.smk
+++ b/workflow/rules/genomes.smk
@@ -310,7 +310,7 @@ rule multiqc_mapping_genome:
     log:
         "logs/genomes/alignment/multiqc.log",
     wrapper:
-        "v1.19.1/bio/multiqc"
+        "v3.3.6/bio/multiqc"
 
 
 rule pileup_MAGs:


### PR DESCRIPTION
There is an error in the rule `multiqc_mapping_genome` due to an incomptability with python 3.12 (see [this issue](https://github.com/metagenome-atlas/atlas/issues/702)). The problem comes from an incompatibility of MultiQC with Python3.12, which was fixed [here](https://github.com/MultiQC/MultiQC/pull/2113/files). 
Atlas uses a very old wrapper for multiqc and updating it should fix the issue.

This should fix https://github.com/metagenome-atlas/atlas/issues/702